### PR TITLE
fix: when no priority is configured

### DIFF
--- a/process/sitemap.js
+++ b/process/sitemap.js
@@ -120,7 +120,7 @@ if(typeof pConfig.ABE_WEBSITE !== 'undefined' && pConfig.ABE_WEBSITE !== null) {
 				}
 			}
 
-			process.send('finished');
+			process.send(JSON.stringify({msg: "exit"}));
 			process.exit(0)
 		})
 }

--- a/process/sitemap.js
+++ b/process/sitemap.js
@@ -26,7 +26,7 @@ function createXml(list, domain, priorities) {
 			var newdate = year + "-" + ((month < 10) ? "0" + month : month) + "-" + ((day < 10) ? "0" + day : day);
 
 			var priority = "0.5";
-			if(typeof priorities[file.abe_meta.template] !== 'undefined' && priorities[file.abe_meta.template] !== null) {
+			if(priorities && typeof priorities[file.abe_meta.template] !== 'undefined' && priorities[file.abe_meta.template] !== null) {
 				priority = priorities[file.abe_meta.template];
 			}
 

--- a/routes/get/generate.js
+++ b/routes/get/generate.js
@@ -4,11 +4,9 @@ var fs = require('fs');
 
 var route = function route(req, res, next, abe) {
 
-  if (abe.abeExtend.process('sitemap')) {
-  	res.send('sitemap is being generated. It may take a while if you have a lot of files');
-  }else {
- 		res.send('cannot run process sitemap, because an other one is already running');
-  }
+  abe.abeExtend.process('sitemap', [''], function(data) {
+    res.send("Sitemap generated");
+  });
 }
 
 exports.default = route


### PR DESCRIPTION
The parameter "priorities" is optional, but if we do not set it up, the plugin failed and no sitemap is generated. This is a fix.
The process ended abe because it sent a bad message. This is a fix.